### PR TITLE
build: Fix up build step to copy headers and lib to install folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,16 +9,21 @@
         ["bash", "-c", "#{os == 'darwin' ? 'make' : 'echo'}"],
         ["bash", "-c", "#{os == 'macOS' ? 'make' : 'echo'}"],
         ["bash", "-c", "#{os == 'linux' ? 'CFLAGS=-fPIC make' : 'echo'}"],
-        ["ar", "rcs", "libfzy.a", "src/match.o", "src/choices.o", "src/options.o"]
+        ["mkdir", "#{self.install / 'include'}"],
+        ["cp", "src/options.h", "#{self.install / 'include'}"],
+        ["cp", "src/match.h", "#{self.install / 'include'}"],
+        ["cp", "src/choices.h", "#{self.install / 'include'}"],
+        ["ar", "rcs", "libfzy.a", "src/match.o", "src/choices.o", "src/options.o"],
+        ["cp", "libfzy.a", "#{self.lib}"]
     ],
     "buildsInSource": true,
     "exportedEnv": {
         "FZY_INCLUDE_PATH": {
-            "val": "#{self.target_dir / 'src'}",
+            "val": "#{self.install / 'include'}",
             "scope": "global"
         },
         "FZY_LIB_PATH": {
-            "val": "#{self.target_dir}",
+            "val": "#{self.lib}",
             "scope": "global"
         }
     }


### PR DESCRIPTION
I hit this same issue - https://github.com/onivim/oni2/issues/2782 - when trying to build `reason-fzy` directly.

It turns out that the `libfzy.a` and headers weren't always copied to the `install` folder - this updates the `package.json` environment variables to fix that.